### PR TITLE
Added attachments and inlines to Message

### DIFF
--- a/mailgun/api/client.py
+++ b/mailgun/api/client.py
@@ -44,9 +44,12 @@ class MailgunClient(object):
             NotFoundException: The url isn't existed.
             ServerErrorsException: The server has some errors occured.
         """
+        files = parameters.pop('files', None)
+
         try:
             func = getattr(requests, method)
-            resp = func(url, auth=("api", self.api_key), data=parameters)
+            resp = func(url, auth=("api", self.api_key), data=parameters,
+                        files=files)
             return self.response(resp)
         except Exception as e:
             raise e

--- a/mailgun/parameter/message.py
+++ b/mailgun/parameter/message.py
@@ -9,6 +9,8 @@ TODO:
     add_mime_message
 """
 
+import os.path
+from mimetypes import guess_type
 from lepl.apps import rfc3696
 
 
@@ -18,7 +20,7 @@ class Message(object):
 
     Attributes:
         data: A dict contains the detail info of message
-        email_validator: An email validator
+        email_validator: An email valdiator
     """
 
     def __init__(self):
@@ -103,21 +105,36 @@ class Message(object):
         """
         self.data["html"] = html
 
-    def add_attachment(self, attachment):
+    def add_attachment(self, attachment, name=None, content_type=None):
         """Add attachment
 
         Args:
             attachment: File attachment
+            name: Attachment name
+            content_type: Attachment content type
         """
-        pass
+        if not self.data.get('files'):
+            self.data['files'] = []
+
+        if not name:
+            name = os.path.basename(attachment.name)
+        if not content_type:
+            ct = guess_type(attachment.name)[0]
+            content_type = ct if ct else ''
+
+        self.data['files'].append(
+            ('attachment', (name, attachment, content_type)))
 
     def add_inline(self, inline):
         """Add inline
 
         Args
-            inline: The inline data
+            inline: File Inline
         """
-        pass
+        if not self.data.get('files'):
+            self.data['files'] = []
+
+        self.data['files'].append(('inline', inline))
 
     def add_tag(self, tag):
         """Add tag


### PR DESCRIPTION
I'm completing the `add_attachment` and `add_inline` methods on `Message` class. In the `add_attachment` method I opted to auto infer the content type.

Example of `add_attachment`:

``` python
msg = Message()
attachment = open('attachment.pdf','rb')
msg.add_attachment(attachment)
```
